### PR TITLE
fix FTP file download problem in Chrome

### DIFF
--- a/ftp/command.go
+++ b/ftp/command.go
@@ -281,8 +281,12 @@ func (commandCwd) RequireAuth() bool  { return true }
 func (commandCwd) Execute(ctx context.Context, c *ServerConn, cmd *Command) {
 	path := c.buildPath(cmd.Arg)
 	stat, err := c.fileSystem().Stat(ctx, path)
-	if err != nil || !stat.IsDir() {
+	if err != nil {
 		c.WriteReply(StatusNeedSomeUnavailableResource, "No such directory.")
+		return
+	}
+	if !stat.IsDir() {
+		c.WriteReply(StatusActionAborted, "Not a directory.")
 		return
 	}
 	c.pwd = path


### PR DESCRIPTION
> https://bugs.chromium.org/p/chromium/issues/detail?id=96401
>
> FTP: fix compatibility with servers which send 451 response
> for CWD command.
>
> According to RFC 959 451 is not a valid response code for CWD
> command, but it is reasonable to handle it in the same way
> as the 550 response.